### PR TITLE
Contact.toString: truncate note, photo, unknown properties

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ androidx-rest-rules = "1.6.1"
 desugar = "2.1.2"
 dokka = "1.9.20"
 ezvcard = "0.12.1"
+guava = "33.3.1-android"
 kotlin = "2.0.21"
 junit = "4.13.2"
 
@@ -15,6 +16,7 @@ androidx-test-runner = { module = "androidx.test:runner", version.ref = "android
 androidx-test-rules = { module = "androidx.test:rules", version.ref = "androidx-rest-rules" }
 desugar = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugar" }
 ezvcard = { module = "com.googlecode.ez-vcard:ez-vcard", version.ref = "ezvcard" }
+guava = { module = "com.google.guava:guava", version.ref = "guava" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 junit = { module = "junit:junit", version.ref = "junit" }
 

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -86,6 +86,7 @@ dependencies {
     coreLibraryDesugaring(libs.desugar)
 
     implementation(libs.androidx.annotation)
+    implementation(libs.guava)
 
     // ez-vcard to parse/generate vCards
     api(libs.ezvcard) {    // requires Java 8

--- a/lib/src/main/kotlin/at/bitfire/vcard4android/Contact.kt
+++ b/lib/src/main/kotlin/at/bitfire/vcard4android/Contact.kt
@@ -6,6 +6,8 @@ package at.bitfire.vcard4android
 
 import at.bitfire.vcard4android.property.CustomScribes.registerCustomScribes
 import at.bitfire.vcard4android.property.XAbDate
+import com.google.common.base.Ascii
+import com.google.common.base.MoreObjects
 import ezvcard.VCardVersion
 import ezvcard.io.json.JCardReader
 import ezvcard.io.text.VCardReader
@@ -80,6 +82,8 @@ data class Contact(
         const val DATE_PARAMETER_OMIT_YEAR = "X-APPLE-OMIT-YEAR"
         const val DATE_PARAMETER_OMIT_YEAR_DEFAULT = 1604
 
+        const val TO_STRING_MAX_VALUE_SIZE = 2000
+
         /**
          * Parses an InputStream that contains a vCard.
          *
@@ -147,6 +151,45 @@ data class Contact(
             false
 
     override fun hashCode() = compareFields().contentHashCode()
+
+    /**
+     * Implements [Object.toString]. Truncates properties with potential big values:
+     *
+     * - [photo]
+     * - [unknownProperties]
+     */
+    override fun toString() = MoreObjects.toStringHelper(this)
+        .omitNullValues()
+        .add("uid", uid)
+        .add("group", group)
+        .add("members", members)
+        .add("displayName", displayName)
+        .add("prefix", prefix)
+        .add("givenName", givenName)
+        .add("middleName", middleName)
+        .add("familyName", familyName)
+        .add("suffix", suffix)
+        .add("phoneticGivenName", phoneticGivenName)
+        .add("phoneticMiddleName", phoneticMiddleName)
+        .add("phoneticFamilyName", phoneticFamilyName)
+        .add("nickName", nickName)
+        .add("organization", organization)
+        .add("jobTitle", jobTitle)
+        .add("jobDescription", jobDescription)
+        .add("phoneNumbers", phoneNumbers)
+        .add("emails", emails)
+        .add("impps", impps)
+        .add("addresses", addresses)
+        .add("categories", categories)
+        .add("urls", urls)
+        .add("relations", relations)
+        .add("note", note?.let { Ascii.truncate(it, TO_STRING_MAX_VALUE_SIZE, "...") })
+        .add("anniversary", anniversary)
+        .add("birthDay", birthDay)
+        .add("customDates", customDates)
+        .add("photo", photo?.let { "byte[${it.size}]" })
+        .add("unknownProperties", unknownProperties?.let { Ascii.truncate(it, TO_STRING_MAX_VALUE_SIZE, "...") })
+        .toString()
 
 
     interface Downloader {

--- a/lib/src/test/kotlin/at/bitfire/vcard4android/ContactTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/vcard4android/ContactTest.kt
@@ -50,7 +50,7 @@ class ContactTest {
             members = mutableSetOf("1", "2", "3"),
             emails = LinkedList(listOf(LabeledProperty(Email("test@example.com")))),
             note = "Some Text\n".repeat(1000),
-            photo = ByteArray(10*1024*1024) { 'A'.toByte() },  // 10 MB
+            photo = ByteArray(10*1024*1024) { 'A'.code.toByte() },  // 10 MB
             unknownProperties = "UNKNOWN:Property\n".repeat(1000)
         )
         val result = c.toString()

--- a/lib/src/test/kotlin/at/bitfire/vcard4android/ContactTest.kt
+++ b/lib/src/test/kotlin/at/bitfire/vcard4android/ContactTest.kt
@@ -11,6 +11,7 @@ import ezvcard.parameter.ImppType
 import ezvcard.parameter.RelatedType
 import ezvcard.parameter.TelephoneType
 import ezvcard.property.Birthday
+import ezvcard.property.Email
 import ezvcard.util.PartialDate
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
@@ -26,6 +27,7 @@ import java.nio.charset.Charset
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
+import java.util.LinkedList
 
 class ContactTest {
 
@@ -38,6 +40,21 @@ class ContactTest {
         val os = ByteArrayOutputStream()
         c.writeVCard(vCardVersion, os)
         return Contact.fromReader(InputStreamReader(ByteArrayInputStream(os.toByteArray()), Charsets.UTF_8), false,null).first()
+    }
+
+
+    @Test
+    fun testToString_TruncatesLargeFields() {
+        val c = Contact(
+            displayName = "Test",
+            members = mutableSetOf("1", "2", "3"),
+            emails = LinkedList(listOf(LabeledProperty(Email("test@example.com")))),
+            note = "Some Text\n".repeat(1000),
+            photo = ByteArray(10*1024*1024) { 'A'.toByte() },  // 10 MB
+            unknownProperties = "UNKNOWN:Property\n".repeat(1000)
+        )
+        val result = c.toString()
+        assertTrue(result.length < 4500)   // 2000 note + 2000 unknown properties + rest
     }
 
 


### PR DESCRIPTION
I have added Guava for

- `MoreObjects.toStringHelper()`
- `Ascii.truncate()`

The `photo` is now shown as size, `note` and `unknownProperties` are truncated to max. 2000 characters.

Other potentially large fields like the list of members are kept as they are for now.